### PR TITLE
Fixed compatibility with TypeScript 3.9.6

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,3 @@
-export { mockGlobal, mockInstanceOf, mockStructure } from "./src/mocking";
-export * from "./src/TestEnvironment";
+import TestEnvironment from './src/TestEnvironment';
+export { mockGlobal, mockInstanceOf, mockStructure } from './src/mocking';
+export default TestEnvironment;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,17 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 var mocking_1 = require("./src/mocking");
-exports.mockGlobal = mocking_1.mockGlobal;
-exports.mockInstanceOf = mocking_1.mockInstanceOf;
-exports.mockStructure = mocking_1.mockStructure;
-__export(require("./src/TestEnvironment"));
+Object.defineProperty(exports, "mockGlobal", { enumerable: true, get: function () { return mocking_1.mockGlobal; } });
+Object.defineProperty(exports, "mockInstanceOf", { enumerable: true, get: function () { return mocking_1.mockInstanceOf; } });
+Object.defineProperty(exports, "mockStructure", { enumerable: true, get: function () { return mocking_1.mockStructure; } });
+__exportStar(require("./src/TestEnvironment"), exports);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const TestEnvironment_1 = __importDefault(require("./src/TestEnvironment"));
 var mocking_1 = require("./src/mocking");
-Object.defineProperty(exports, "mockGlobal", { enumerable: true, get: function () { return mocking_1.mockGlobal; } });
-Object.defineProperty(exports, "mockInstanceOf", { enumerable: true, get: function () { return mocking_1.mockInstanceOf; } });
-Object.defineProperty(exports, "mockStructure", { enumerable: true, get: function () { return mocking_1.mockStructure; } });
+exports.mockGlobal = mocking_1.mockGlobal;
+exports.mockInstanceOf = mocking_1.mockInstanceOf;
+exports.mockStructure = mocking_1.mockStructure;
 exports.default = TestEnvironment_1.default;

--- a/index.js
+++ b/index.js
@@ -1,17 +1,11 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __exportStar = (this && this.__exportStar) || function(m, exports) {
-    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const TestEnvironment_1 = __importDefault(require("./src/TestEnvironment"));
 var mocking_1 = require("./src/mocking");
 Object.defineProperty(exports, "mockGlobal", { enumerable: true, get: function () { return mocking_1.mockGlobal; } });
 Object.defineProperty(exports, "mockInstanceOf", { enumerable: true, get: function () { return mocking_1.mockInstanceOf; } });
 Object.defineProperty(exports, "mockStructure", { enumerable: true, get: function () { return mocking_1.mockStructure; } });
-__exportStar(require("./src/TestEnvironment"), exports);
+exports.default = TestEnvironment_1.default;

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,4 @@
-export { mockGlobal, mockInstanceOf, mockStructure } from "./src/mocking";
-export * from "./src/TestEnvironment";
+import TestEnvironment from './src/TestEnvironment';
+
+export {mockGlobal, mockInstanceOf, mockStructure} from './src/mocking';
+export default TestEnvironment;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "jest": "^26.1.0",
     "lodash": "^3",
     "ts-jest": "^26.1.1",
-    "typescript": "~3.8.3"
+    "typescript": "^3.9.6"
   },
   "scripts": {
     "build": "tsc",

--- a/src/mocking.js
+++ b/src/mocking.js
@@ -1,28 +1,15 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
     return result;
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.mockStructure = exports.mockInstanceOf = exports.mockRoomPositionConstructor = exports.mockGlobal = void 0;
 const util = __importStar(require("util"));
 const jest_mock_1 = __importDefault(require("jest-mock"));
 /**

--- a/src/mocking.js
+++ b/src/mocking.js
@@ -1,15 +1,28 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
     return result;
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.mockStructure = exports.mockInstanceOf = exports.mockRoomPositionConstructor = exports.mockGlobal = void 0;
 const util = __importStar(require("util"));
 const jest_mock_1 = __importDefault(require("jest-mock"));
 /**
@@ -97,14 +110,12 @@ function mockStructure(structureType, mockedProps = {}) {
     var _a;
     const count = ((_a = structureCounters[structureType]) !== null && _a !== void 0 ? _a : 0) + 1;
     structureCounters[structureType] = count;
+    const id = `${structureType}${count}`;
     return mockInstanceOf({
-        id: `${structureType}${count}`,
-        structureType: structureType,
+        id,
+        structureType,
         toJSON() {
-            return {
-                id: this.id,
-                structureType: this.structureType
-            };
+            return { id, structureType, };
         },
         ...mockedProps
     });

--- a/src/mocking.ts
+++ b/src/mocking.ts
@@ -133,14 +133,12 @@ function mockStructure<T extends StructureConstant>(structureType: T, mockedProp
   const count = (structureCounters[structureType] ?? 0) + 1;
 
   structureCounters[structureType] = count;
+  const id = `${structureType}${count}` as Id<ConcreteStructure<T>>;
   return mockInstanceOf<ConcreteStructure<T>>({
-    id: `${structureType}${count}` as Id<ConcreteStructure<T>>,
-    structureType: structureType as any,
+    id,
+    structureType,
     toJSON() {
-      return {
-        id: this.id,
-        structureType: this.structureType
-      };
+      return {id, structureType,};
     },
     ...mockedProps
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3565,10 +3565,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~3.8:
-  version "3.8.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.9.6:
+  version "3.9.6"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Fixes #7 

Upgrading the version of TypeScript used to compile this project past 3.8.x results in the following error on `yarn build`:

```
$ tsc
src/mocking.ts:141:13 - error TS2589: Type instantiation is excessively deep and possibly infinite.

141         id: this.id,
                ~~~~~~~


Found 1 error.
```

The issue here being that reusing `this.id` causes a recursive type definition on `id` (also on `structureType` on the next line).

Removing the references to `this` in the `toJson` function and instead relying on a function closure flattens the type definition. Allowing this project to compile with typescript@latest (3.9.6).

Also, I had to change the TestEnvironment export in `index.ts` from a `* export` to an `import` with a `default export`. Otherwise Jest could not find the test environment.

---

If you approve this change, and merge this PR, can you bump the version in `package.json` and add a new git tag? I'd like to be able to depend on a specific version instead of master.