### PR TITLE
Using importHelpers with tslib to emit smaller bundle size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,8 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-const TestEnvironment_1 = __importDefault(require("./src/TestEnvironment"));
+const tslib_1 = require("tslib");
 var mocking_1 = require("./src/mocking");
-Object.defineProperty(exports, "mockGlobal", { enumerable: true, get: function () { return mocking_1.mockGlobal; } });
-Object.defineProperty(exports, "mockInstanceOf", { enumerable: true, get: function () { return mocking_1.mockInstanceOf; } });
-Object.defineProperty(exports, "mockStructure", { enumerable: true, get: function () { return mocking_1.mockStructure; } });
-exports.default = TestEnvironment_1.default;
+exports.mockGlobal = mocking_1.mockGlobal;
+exports.mockInstanceOf = mocking_1.mockInstanceOf;
+exports.mockStructure = mocking_1.mockStructure;
+tslib_1.__exportStar(require("./src/TestEnvironment"), exports);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "peerDependencies": {
     "jest": "<=26"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
   "devDependencies": {
     "@types/jest": "^26.0.3",
     "@types/lodash": "^3",

--- a/src/TestEnvironment.js
+++ b/src/TestEnvironment.js
@@ -1,10 +1,8 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-const jest_environment_node_1 = __importDefault(require("jest-environment-node"));
-const setupGlobals_1 = __importDefault(require("./setupGlobals"));
+const tslib_1 = require("tslib");
+const jest_environment_node_1 = tslib_1.__importDefault(require("jest-environment-node"));
+const setupGlobals_1 = tslib_1.__importDefault(require("./setupGlobals"));
 const mocking_1 = require("./mocking");
 class TestEnvironment extends jest_environment_node_1.default {
     async setup() {

--- a/src/mocking.js
+++ b/src/mocking.js
@@ -1,30 +1,8 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.mockStructure = exports.mockInstanceOf = exports.mockRoomPositionConstructor = exports.mockGlobal = void 0;
-const util = __importStar(require("util"));
-const jest_mock_1 = __importDefault(require("jest-mock"));
+const tslib_1 = require("tslib");
+const util = tslib_1.__importStar(require("util"));
+const jest_mock_1 = tslib_1.__importDefault(require("jest-mock"));
 /**
  * Properties I've seen having been accessed internally by Jest's matchers and message formatters (there may be others).
  */

--- a/src/setupGlobals.js
+++ b/src/setupGlobals.js
@@ -1,9 +1,7 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-const lodash_1 = __importDefault(require("lodash"));
+const tslib_1 = require("tslib");
+const lodash_1 = tslib_1.__importDefault(require("lodash"));
 function setupGlobals(globalObject) {
     globalObject._ = lodash_1.default;
     setupConstants(globalObject);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "strict": true,                           /* Enable all strict type-checking options. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "importHelpers": true,                    /* Import emit helpers (e.g. '__extends', etc) from tslib. Emit smaller bundle. */
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,6 +3519,11 @@ ts-jest@^26.1.1:
     semver "7.x"
     yargs-parser "18.x"
 
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"


### PR DESCRIPTION
We can emit smaller bundles by using `tslib` as a runtime dep which will remove duplication of generated helper functions. You can see the size reduction in the build `.js` files in this PR.

Requires adding the `importHelper` flag to `tsconfig.json`.

Explanation:
https://spblog.net/post/2018/10/26/TypeScript-Tips-How-to-reduce-the-size-of-a-bundle

Real world usage:
https://angular.io/guide/migration-update-libraries-tslib