### PR TITLE
Allow mocking array of constants avoiding wrapping in an object

### DIFF
--- a/src/mocking.d.ts
+++ b/src/mocking.d.ts
@@ -3,7 +3,7 @@
  * Generic type for partial implementations of interfaces.
  */
 declare type DeepPartial<T> = {
-    [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>> : T[P] extends Id<infer V> ? Id<V> : T[P] extends (object | undefined) ? DeepPartial<T[P]> : T[P];
+    [P in keyof T]?: T[P] extends Array<string> ? Array<string> : T[P] extends Array<number> ? Array<number> : T[P] extends Array<infer U> ? Array<DeepPartial<U>> : T[P] extends Id<infer V> ? Id<V> : T[P] extends (object | undefined) ? DeepPartial<T[P]> : T[P];
 } & {
     [key: string]: any;
 };

--- a/src/mocking.js
+++ b/src/mocking.js
@@ -64,12 +64,15 @@ function mockInstanceOf(mockedProps = {}, allowUndefinedAccess = false) {
     return createMock(mockedProps, allowUndefinedAccess, '');
 }
 exports.mockInstanceOf = mockInstanceOf;
+function isConstant(element) {
+    return typeof element === 'string' || typeof element === 'number';
+}
 function createMock(mockedProps, allowUndefinedAccess, path) {
     const target = {};
     Object.entries(mockedProps).forEach(([propName, mockedValue]) => {
         target[propName] =
             typeof mockedValue === 'function' ? jest_mock_1.default.fn(mockedValue)
-                : Array.isArray(mockedValue) ? mockedValue.map((element, index) => createMock(element, allowUndefinedAccess, concatenatePath(path, `${propName}[${index}]`)))
+                : Array.isArray(mockedValue) ? mockedValue.map((element, index) => isConstant(element) ? element : createMock(element, allowUndefinedAccess, concatenatePath(path, `${propName}[${index}]`)))
                     : typeof mockedValue === 'object' && shouldMockObject(mockedValue) ? createMock(mockedValue, allowUndefinedAccess, concatenatePath(path, propName))
                         : mockedValue;
     });

--- a/src/mocking.js
+++ b/src/mocking.js
@@ -38,6 +38,8 @@ const jestInternalStuff = [
     "@@__IMMUTABLE_RECORD__@@",
     "_isMockFunction",
     "mockClear",
+    "tagName",
+    "hasAttribute",
 ];
 /**
  * Mocks a global object instance, like Game or Memory.

--- a/src/mocking.spec.js
+++ b/src/mocking.spec.js
@@ -34,6 +34,10 @@ describe('mockInstanceOf', () => {
         expect((_a = mockCreep.room.controller) === null || _a === void 0 ? void 0 : _a.owner.username).toEqual('some-user');
         expect(mockCreep.build(mocking_1.mockInstanceOf())).toEqual(OK);
     });
+    it('allows mocking constants', () => {
+        const mockSpawning = mocking_1.mockInstanceOf({ directions: [TOP] });
+        expect(mockSpawning.directions).toEqual([TOP]);
+    });
     it('throws if you access an unmocked field of a deep partial mock', () => {
         const mockCreep = mocking_1.mockInstanceOf({
             body: [

--- a/src/mocking.spec.ts
+++ b/src/mocking.spec.ts
@@ -36,6 +36,11 @@ describe('mockInstanceOf', () => {
     expect(mockCreep.build(mockInstanceOf<ConstructionSite>())).toEqual(OK);
   });
 
+  it('allows mocking constants', () => {
+    const mockSpawning = mockInstanceOf<Spawning>({ directions: [TOP] })
+    expect(mockSpawning.directions).toEqual([TOP])
+  })
+
   it('throws if you access an unmocked field of a deep partial mock', () => {
     const mockCreep = mockInstanceOf<Creep>({
       body: [

--- a/src/mocking.ts
+++ b/src/mocking.ts
@@ -53,6 +53,8 @@ const jestInternalStuff: Array<symbol | string | number> = [
   "@@__IMMUTABLE_RECORD__@@",
   "_isMockFunction",
   "mockClear",
+  "tagName",
+  "hasAttribute",
 ];
 
 /**


### PR DESCRIPTION
It was not possible to mock an array of constant values like body parts or directions.
```
    const mockSpawning = mockInstanceOf<Spawning>({ directions: [TOP] })
    expect(mockSpawning.directions).toEqual([TOP])
```
Adds more stuff to `jestInternalStuff`