### PR TITLE
Move lodash from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
   "peerDependencies": {
     "jest": ">=27"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^3"
+  },
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@types/lodash": "^3",
     "@types/node": "^13.1.0",
     "@types/screeps": "^3.0.0",
     "jest": "^27.1.0",
-    "lodash": "^3",
     "ts-jest": "^27.0.5",
     "typescript": "^3.9.6",
     "semantic-release": "^17.4.7"


### PR DESCRIPTION
This was causing a missing dependency issue since it's used in `setupGlobals`, but not included in the `dependencies`. 